### PR TITLE
Use --api-key and --source

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,9 +21,6 @@ jobs:
       - uses: actions/setup-dotnet@v1
         with:
           dotnet-version: 3.1.x
-          source-url: https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json
-        env:
-          NUGET_AUTH_TOKEN: ${{ github.token }}
 
       - name: Create a .NET Core class library project
         run: dotnet new classlib
@@ -35,7 +32,7 @@ jobs:
         run: dotnet pack -p:RepositoryUrl=https://github.com/${{ github.repository }} -p:PackageVersion=${{ env.VERSION }}
 
       - name: Publish package
-        run: dotnet nuget push bin/Debug/*.nupkg
+        run: dotnet nuget push bin/Debug/*.nupkg --api-key ${{ secrets.GITHUB_TOKEN }} --source https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json
 
       - run: gh api repos/${{ github.repository_owner }}/nuget-install/dispatches <<< '{"event_type":"build"}' --input -
         if: ${{ env.REPO_TOKEN != null }}


### PR DESCRIPTION
The only reliable way to publish NuGet packages is using the --api-key and --source envvars.